### PR TITLE
Custom Scopes for 1.50

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:16.0-bookworm


### PR DESCRIPTION
No scope change needed as the `retrieveUserUsingJWT` is being called within the `/oauth-redirect`. Just removed version in docker.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207151784813977